### PR TITLE
Scroll to product header on collapse shown

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,6 +64,11 @@ function setHighlight(hash) {
   $('a[href="' + hash + '"]').addClass('nav-active');
 }
 
+// returns true if the top of the element is visible in the current window
+function isInView(element) {
+  return $(element).offset().top >= $(window).scrollTop();
+}
+
 // product page needs event handlers to make the borders look nice w/
 // collapsing, and to load individual product pages
 function setupProdHandlers(){
@@ -79,10 +84,12 @@ function setupProdHandlers(){
 
   $('#products-list .collapse').on('shown.bs.collapse', function() {
     var collapseHeader = $('a[href="#' + $(this).attr('id') + '"]');
-    if(collapseHeader)
-    $('html, body').animate( {
-      scrollTop: $(collapseHeader).offset().top - 5 // a bit of spacing for aesthetics
-    }, 200);
+    if(!isInView(collapseHeader)) {
+      console.log('in view');
+      $('html, body').animate( {
+        scrollTop: $(collapseHeader).offset().top
+      }, 200);
+    }
   });
 
   // gives the product-selected class to the clicked product header

--- a/main.js
+++ b/main.js
@@ -77,6 +77,14 @@ function setupProdHandlers(){
     $('#last-product-header').removeClass('rounded-0');
   });
 
+  $('#products-list .collapse').on('shown.bs.collapse', function() {
+    var collapseHeader = $('a[href="#' + $(this).attr('id') + '"]');
+    if(collapseHeader)
+    $('html, body').animate( {
+      scrollTop: $(collapseHeader).offset().top - 5 // a bit of spacing for aesthetics
+    }, 200);
+  });
+
   // gives the product-selected class to the clicked product header
   $('.product-header').on('click', function() {
     var collapseDiv = $(this).attr('href');


### PR DESCRIPTION
Adjust the scroll to position the selected product header at the top of the window when its collapse body is shown, only if it would otherwise be out of view.

Currently, there is no scrolling, and when the collapse is open, the user could have to manually scroll up to find the top. Not that elegant.


